### PR TITLE
Remove test which prevents build

### DIFF
--- a/src/tests/rect-test.cpp
+++ b/src/tests/rect-test.cpp
@@ -251,7 +251,6 @@ TYPED_TEST(GenericRectTest, Emptiness) {
     EXPECT_FALSE(empty);
     EXPECT_TRUE(!empty);
     EXPECT_FALSE(oa.empty());
-    EXPECT_TRUE(oa);
     EXPECT_FALSE(!oa);
 }
 


### PR DESCRIPTION
This removes the statement which causes the build to fail, see #7 
