### PR TITLE
More typos (cont.)

### DIFF
--- a/src/2geom/generic-rect.h
+++ b/src/2geom/generic-rect.h
@@ -89,7 +89,7 @@ public:
         f[Y] = CInterval(y0, y1);
     }
     /** @brief Create a rectangle from a range of points.
-     * The resulting rectangle will contain all ponts from the range.
+     * The resulting rectangle will contain all points from the range.
      * The return type of iterators must be convertible to Point.
      * The range must not be empty. For possibly empty ranges, see OptRect.
      * @param start Beginning of the range
@@ -374,7 +374,7 @@ public:
     }
     
     /** @brief Create a rectangle from a range of points.
-     * The resulting rectangle will contain all ponts from the range.
+     * The resulting rectangle will contain all points from the range.
      * If the range contains no points, the result will be an empty rectangle.
      * The return type of iterators must be convertible to the corresponding
      * point type (Point or IntPoint).

--- a/src/2geom/sbasis-roots.cpp
+++ b/src/2geom/sbasis-roots.cpp
@@ -390,8 +390,8 @@ static std::vector<Interval> fuseContiguous(std::vector<Interval> const &sets, d
    -compute f at both ends of the given segment [a,b].
    -compute bounds m<df(t)<M for df on the segment.
     Suppose f(a) is between two 'levels' c and C. Then
-      f wont enter c before a + (f(a)-c.max())/m
-      f wont enter C before a + (C.min()-f(a))/M
+      f won't enter c before a + (f(a)-c.max())/m
+      f won't enter C before a + (C.min()-f(a))/M
     From this we conclude nothing happens before a'=a+min((f(a)-c.max())/m,(C.min()-f(a))/M).
     We do the same for b: compute some b' such that nothing happens in (b',b].
     -if [a',b'] is not empty, repeat the process with [a',(a'+b')/2] and [(a'+b')/2,b'].


### PR DESCRIPTION
Found via `codespell -q 3 -I ../lib2geom-whitelist.txt --skip="./src/googletest"`  
where whitelist consisted of:
```
als
amin
ang
behaviour
colour
iff
licenced
nd
nott
substract
te
```